### PR TITLE
Rename FixtureFactory::Registry.fixture to FixtureFactory::Registry.factory

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ case class. Definitions are made with the `.define_factories` and `.fixture` met
 ```ruby
 class AccountTest < ActiveSupport::TestCase
   define_factories do
-    fixture(:account)
-    fixture(:enterprise_account, class: 'Account') do
+    factory(:account)
+    factory(:enterprise_account, class: 'Account') do
       { plan: :enterprise }
     end
   end
@@ -61,8 +61,8 @@ fixture method you source fixtures from. Fixture with non-standard names can get
 ```ruby
 class RecipeTest < ActiveSupport::TestCase
   define_factories do
-    fixture(:recipe) # infers "Recipe" and "recipes"
-    fixture(:cake_recipe, parent: :recipe) do
+    factory(:recipe) # infers "Recipe" and "recipes"
+    factory(:cake_recipe, parent: :recipe) do
       { name: "Cake" }
     end
   end
@@ -74,7 +74,7 @@ end
 ```ruby
 class RecipeTest < ActiveSupport::TestCase
   define_factories do
-    fixture(:cake_recipe, class: "Recipe", via: :recipes) do
+    factory(:cake_recipe, class: "Recipe", via: :recipes) do
       { name: "Cake" }
     end
   end
@@ -89,8 +89,8 @@ fixtures. This is done with the `via` and `like` options:
 ```ruby
 class UserTest < ActiveSupport::TestCase
   define_factories do
-    fixture(:user, like: :bob)
-    fixture(:admin_user, class: 'User', like: :bob, via: :users) do
+    factory(:user, like: :bob)
+    factory(:admin_user, class: 'User', like: :bob, via: :users) do
       { role: :admin }
     end
   end
@@ -106,13 +106,13 @@ a `parent` factory to inherit options from. Here's an example:
 ```ruby
 class ActiveSupport::TestCase
   define_factories do
-    fixture(:address)
+    factory(:address)
   end
 end
 
 class AddressTest < ActiveSupport::TestCase
   define_factories do
-    fixture(:primary_address, parent: :address)
+    factory(:primary_address, parent: :address)
       { primary: true }
     end
   end
@@ -128,7 +128,7 @@ seed unique values.
 ```ruby
 class ArticleTest < ActiveSupport::TestCase
   define_factories do
-    fixture(:article) do |count| # starts at 1
+    factory(:article) do |count| # starts at 1
       { title: "Unique Article", slug: "article-#{count}" }
     end
   end
@@ -147,7 +147,7 @@ Generates a hash of attributes given a factory name and an optional hash of over
 ```ruby
 class UsersControllerTest < ActionDispatch::IntegrationTest
   define_factories do
-    fixture(:user) do
+    factory(:user) do
       { email: 'user@example.com', admin: false }
     end
   end
@@ -165,7 +165,7 @@ Generates an array of hash attributes given a factory name, a count, and an opti
 ```ruby
 class BooksControllerTest < ActionDispatch::IntegrationTest
   define_factories do
-    fixture(:book) do
+    factory(:book) do
       { title: 'Ruby Under a Microscope' }
     end
   end
@@ -183,7 +183,7 @@ Generates an unpersisted instance of a model given a factory name and an optiona
 ```ruby
 class CourseTest < ActiveSupport::TestCase
   define_factories do
-    fixture(:course) do
+    factory(:course) do
       { name: 'Rails for Zombies' }
     end
   end
@@ -201,7 +201,7 @@ Generates an array of unpersisted model instances given a factory name and an op
 ```ruby
 class PostTest < ActiveSupport::TestCase
   define_factories do
-    fixture(:post) do
+    factory(:post) do
       { title: 'Rails 5.2' }
     end
   end
@@ -219,7 +219,7 @@ Generates a persisted model instance given a factory name and an optional hash o
 ```ruby
 class CommentTest < ActiveSupport::TestCase
   define_factories do
-    fixture(:comment) do
+    factory(:comment) do
       { content: 'Hello World!', post: build(:post) }
     end
   end
@@ -237,7 +237,7 @@ Generates an array of persisted model instances given a factory name and an opti
 ```ruby
 class BlogTest < ActiveSupport::TestCase
   define_factories do
-    fixture(:blog) do
+    factory(:blog) do
       { name: 'Giant Robots Smashing Into Other Giant Robots' }
     end
   end

--- a/lib/fixture_factory/registry.rb
+++ b/lib/fixture_factory/registry.rb
@@ -36,16 +36,16 @@ module FixtureFactory
       # === Example
       #
       # define_factories do
-      #   fixture(:user, like: :bob)
-      #   fixture(:active_user, parent: :user) do
+      #   factory(:user, like: :bob)
+      #   factory(:active_user, parent: :user) do
       #     { active: true }
       #   end
-      #   fixture(:cool_user, class: 'User') do
+      #   factory(:cool_user, class: 'User') do
       #     { status: :cool }
       #   end
-      #   fixture(:admin, via: :users, like: :bob_admin, class: 'User')
+      #   factory(:admin, via: :users, like: :bob_admin, class: 'User')
       # end
-      def fixture(name, options = {}, &block)
+      def factory(name, options = {}, &block)
         parent = all_factory_definitions[options[:parent]]
         options[:parent] = parent if options.key?(:parent)
         options[:block]  = block if block
@@ -59,12 +59,12 @@ module FixtureFactory
       #
       # class SomeTest < ActiveSupport::TestCase
       #   define_factories do
-      #     fixture(:blog)
+      #     factory(:blog)
       #   end
       # end
       #
       # SomeTest.define_factories do
-      #   fixture(:post)
+      #   factory(:post)
       # end
       def define_factories(&block)
         self.fixture_factory_definitions = {}.with_indifferent_access

--- a/test/fixtury_test.rb
+++ b/test/fixtury_test.rb
@@ -6,7 +6,7 @@ class FixturyTest < FixtureFactory::TestCase
   include FixtureFactory::Registry
 
   define_factories do
-    fixture(:post, class: Post) do
+    factory(:post, class: Post) do
       post_factory_attributes
     end
   end

--- a/test/methods_test.rb
+++ b/test/methods_test.rb
@@ -8,15 +8,15 @@ module FixtureFactory
     include FixtureFactory::Registry
 
     define_factories do
-      fixture(:user, class: User) do
+      factory(:user, class: User) do
         user_factory_attributes
       end
 
-      fixture(:address, class: Address) do
+      factory(:address, class: Address) do
         address_factory_attributes
       end
 
-      fixture(:account, class: Account) do
+      factory(:account, class: Account) do
         account_factory_attributes
       end
     end

--- a/test/registry_test.rb
+++ b/test/registry_test.rb
@@ -24,7 +24,7 @@ module FixtureFactory
     attr_reader :registry, :child_registry
 
     test ".fixture defines fixturies" do
-      block = proc { fixture(:recipe_fixtury, class: Recipe) }
+      block = proc { factory(:recipe_fixtury, class: Recipe) }
       registry.define_factories(&block)
       assert_nothing_raised do
         assert_instance_of FixtureFactory::Definition, registry.all_factory_definitions.fetch(:recipe_fixtury)
@@ -33,10 +33,10 @@ module FixtureFactory
 
     test ".all_factory_definitions returns inherited hash of fixturies" do
       registry.define_factories do
-        fixture(:recipe, class: Recipe)
+        factory(:recipe, class: Recipe)
       end
       child_registry.define_factories do
-        fixture(:recipe_with_instructions, class: Recipe) do
+        factory(:recipe_with_instructions, class: Recipe) do
           { instructions: 'Step 1...' }
         end
       end
@@ -49,10 +49,10 @@ module FixtureFactory
       parent_block = proc { { name: 'Parent' } }
       child_block  = proc { { name: 'Child' } }
       registry.define_factories do
-        fixture(:recipe, class: Recipe, &parent_block)
+        factory(:recipe, class: Recipe, &parent_block)
       end
       child_registry.define_factories do
-        fixture(:recipe, class: Recipe, &child_block)
+        factory(:recipe, class: Recipe, &child_block)
       end
       assert_equal 'Parent', FixtureFactory.build(:recipe, scope: registry).name
       assert_equal 'Child', FixtureFactory.build(:recipe, scope: child_registry).name

--- a/test/sequence_usage_test.rb
+++ b/test/sequence_usage_test.rb
@@ -8,7 +8,7 @@ module FixtureFactory
     include FixtureFactory::Registry
 
     define_factories do
-      fixture(:user) do |count|
+      factory(:user) do |count|
         { email: "user-#{count}@example.com" }
       end
     end


### PR DESCRIPTION
Renames `fixture` to `factory` in a `define_factories` block.