### PR TITLE
Defer factory class constantization with class_name option

### DIFF
--- a/lib/fixture_factory/definition.rb
+++ b/lib/fixture_factory/definition.rb
@@ -4,16 +4,15 @@ module FixtureFactory
   class Definition # :nodoc:
     EMPTY_BLOCK = proc {}
 
-    attr_reader   :klass
     attr_writer   :block
-    attr_accessor :fixture_method, :fixture_name, :parent, :sequence
+    attr_accessor :class_name, :fixture_method, :fixture_name, :parent, :sequence
 
     def initialize(name, options = {})
-      self.parent         = options.fetch(:parent) { default_parent_for(name) }
-      self.klass          = options.fetch(:class)  { parent.klass }
-      self.fixture_method = options.fetch(:via)    { parent.fixture_method }
-      self.fixture_name   = options.fetch(:like)   { parent.fixture_name }
-      self.block          = options.fetch(:block)  { EMPTY_BLOCK }
+      self.parent         = options.fetch(:parent)     { default_parent_for(name) }
+      self.class_name     = options.fetch(:class_name) { parent.class_name }
+      self.fixture_method = options.fetch(:via)        { parent.fixture_method }
+      self.fixture_name   = options.fetch(:like)       { parent.fixture_name }
+      self.block          = options.fetch(:block)      { EMPTY_BLOCK }
       self.sequence       = Sequence.new
     end
 
@@ -29,15 +28,10 @@ module FixtureFactory
       end
     end
 
-    def klass=(new_class)
-      @klass = case new_class
-      when String
-        new_class.to_s.constantize
-      else
-        new_class
-      end
+    def klass
+      @klass ||= class_name.to_s.constantize
     rescue NameError
-      raise WrongClassError, new_class
+      raise WrongClassError, class_name
     end
 
     def fixture_args
@@ -76,7 +70,7 @@ module FixtureFactory
         name,
         parent: nil,
         like: nil,
-        class: name.to_s.classify.safe_constantize,
+        class_name: name.to_s.classify,
         via: name.to_s.pluralize,
       )
     end

--- a/lib/fixture_factory/errors.rb
+++ b/lib/fixture_factory/errors.rb
@@ -34,7 +34,7 @@ module FixtureFactory
       super(
         <<~MSG.squish
           No class named "#{class_name}".
-          Try using the `class` option in your definition to specify a valid class name.
+          Try using the `class_name` option in your definition to specify a valid class name.
           https://github.com/Shopify/fixture_factory/blob/master/README.md#naming
         MSG
       )

--- a/lib/fixture_factory/registry.rb
+++ b/lib/fixture_factory/registry.rb
@@ -46,6 +46,14 @@ module FixtureFactory
       #   factory(:admin, via: :users, like: :bob_admin, class: 'User')
       # end
       def factory(name, options = {}, &block)
+        if options.key?(:class)
+          ActiveSupport::Deprecation.warn(<<~MSG.squish)
+            factory class: option is deprecated and will be removed.
+            Please use the class_name: option instead.
+          MSG
+          options[:class_name] ||= options.delete(:class)
+        end
+
         parent = all_factory_definitions[options[:parent]]
         options[:parent] = parent if options.key?(:parent)
         options[:block]  = block if block

--- a/test/definition_test.rb
+++ b/test/definition_test.rb
@@ -14,14 +14,14 @@ module FixtureFactory
     test "#initialize derives from default parent defaults" do
       subject = tested_class.new(:some_fixtury)
       assert_instance_of tested_class, subject.parent
-      assert_nil subject.klass
       assert_nil subject.fixture_name
-      assert_equal 'some_fixturies', subject.fixture_method
+      assert_equal "SomeFixtury", subject.class_name
+      assert_equal "some_fixturies", subject.fixture_method
       assert_same empty_block, subject.instance_variable_get(:@block)
     end
 
     test "#initialize allows explicit parent" do
-      parent  = tested_class.new(:parent_fixtury, class: Object, via: :parent_method, like: :parent_name)
+      parent  = tested_class.new(:parent_fixtury, class_name: "Object", via: :parent_method, like: :parent_name)
       subject = tested_class.new(:child_fixtury, parent: parent)
       assert_same parent, subject.parent
       assert_equal parent.klass, subject.klass
@@ -29,8 +29,8 @@ module FixtureFactory
       assert_equal parent.fixture_name, subject.fixture_name
     end
 
-    test "#initialize allows explicit klass" do
-      subject = tested_class.new(:child_fixtury, class: String)
+    test "#initialize allows explicit class name" do
+      subject = tested_class.new(:child_fixtury, class_name: "String")
       assert_equal String, subject.klass
     end
 
@@ -66,26 +66,21 @@ module FixtureFactory
       assert_equal({ parent: true, child: true }, FixtureFactory.evaluate(subject.block, context: self))
     end
 
-    test "#klass= constantizes strings automatically" do
+    test "#klass constantizes class_name later" do
       subject = tested_class.new(:fixture)
-      subject.klass = "Object"
+      subject.class_name = "Object"
       assert_equal Object, subject.klass
     end
 
-    test "#klass= assigns classes normally" do
+    test "#klass raises WrongClassError when class name is invalid" do
       subject = tested_class.new(:fixture)
-      subject.klass = Object
-      assert_equal Object, subject.klass
-    end
-
-    test "#klass= raises WrongClassError when class name is invalid" do
-      subject = tested_class.new(:fixture)
+      subject.class_name = "TheClassIsALie"
       error = assert_raises(WrongClassError) do
-        subject.klass = "TheClassIsALie"
+        subject.klass
       end
       assert_equal <<~MSG.squish, error.message
         No class named "TheClassIsALie".
-        Try using the `class` option in your definition to specify a valid class name.
+        Try using the `class_name` option in your definition to specify a valid class name.
         https://github.com/Shopify/fixture_factory/blob/master/README.md#naming
       MSG
     end

--- a/test/fixtury_test.rb
+++ b/test/fixtury_test.rb
@@ -6,7 +6,7 @@ class FixturyTest < FixtureFactory::TestCase
   include FixtureFactory::Registry
 
   define_factories do
-    factory(:post, class: Post) do
+    factory(:post, class_name: "Post") do
       post_factory_attributes
     end
   end

--- a/test/methods_test.rb
+++ b/test/methods_test.rb
@@ -8,15 +8,15 @@ module FixtureFactory
     include FixtureFactory::Registry
 
     define_factories do
-      factory(:user, class: User) do
+      factory(:user, class_name: "User") do
         user_factory_attributes
       end
 
-      factory(:address, class: Address) do
+      factory(:address, class_name: "Address") do
         address_factory_attributes
       end
 
-      factory(:account, class: Account) do
+      factory(:account, class_name: "Account") do
         account_factory_attributes
       end
     end

--- a/test/registry_test.rb
+++ b/test/registry_test.rb
@@ -23,20 +23,33 @@ module FixtureFactory
 
     attr_reader :registry, :child_registry
 
-    test ".fixture defines fixturies" do
-      block = proc { factory(:recipe_fixtury, class: Recipe) }
+    test ".factory defines fixture factories" do
+      block = proc { factory(:recipe_fixtury, class_name: "Recipe") }
       registry.define_factories(&block)
       assert_nothing_raised do
         assert_instance_of FixtureFactory::Definition, registry.all_factory_definitions.fetch(:recipe_fixtury)
       end
     end
 
-    test ".all_factory_definitions returns inherited hash of fixturies" do
+    test ".factory works with deprecated class: option" do
+      assert_deprecated do
+        registry.define_factories do
+          factory(:recipe_fixtury, class: "Recipe")
+          factory(:user_fixtury, class: User)
+        end
+      end
+      assert_nothing_raised do
+        assert_equal Recipe, registry.all_factory_definitions.fetch(:recipe_fixtury).klass
+        assert_equal User, registry.all_factory_definitions.fetch(:user_fixtury).klass
+      end
+    end
+
+    test ".all_factory_definitions returns inherited hash of fixture factories" do
       registry.define_factories do
-        factory(:recipe, class: Recipe)
+        factory(:recipe, class_name: "Recipe")
       end
       child_registry.define_factories do
-        factory(:recipe_with_instructions, class: Recipe) do
+        factory(:recipe_with_instructions, class_name: "Recipe") do
           { instructions: 'Step 1...' }
         end
       end
@@ -49,10 +62,10 @@ module FixtureFactory
       parent_block = proc { { name: 'Parent' } }
       child_block  = proc { { name: 'Child' } }
       registry.define_factories do
-        factory(:recipe, class: Recipe, &parent_block)
+        factory(:recipe, class_name: "Recipe", &parent_block)
       end
       child_registry.define_factories do
-        factory(:recipe, class: Recipe, &child_block)
+        factory(:recipe, class_name: "Recipe", &child_block)
       end
       assert_equal 'Parent', FixtureFactory.build(:recipe, scope: registry).name
       assert_equal 'Child', FixtureFactory.build(:recipe, scope: child_registry).name


### PR DESCRIPTION
Defers `String#constantize` calls to factory classes so we don't load models during test boot time. This is especially helpful for apps that include a base set of definitions that may not be used within a given context (eg. running a single test case file).