### PR TITLE
Expose a constant when passing a model reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ case class. Definitions are made with the `.define_factories` and `.fixture` met
 class AccountTest < ActiveSupport::TestCase
   define_factories do
     factory(:account)
-    factory(:enterprise_account, class: 'Account') do
+    factory(:enterprise_account, class: -> { Account }) do
       { plan: :enterprise }
     end
   end
@@ -74,7 +74,7 @@ end
 ```ruby
 class RecipeTest < ActiveSupport::TestCase
   define_factories do
-    factory(:cake_recipe, class: "Recipe", via: :recipes) do
+    factory(:cake_recipe, class: -> { Recipe }, via: :recipes) do
       { name: "Cake" }
     end
   end
@@ -90,7 +90,7 @@ fixtures. This is done with the `via` and `like` options:
 class UserTest < ActiveSupport::TestCase
   define_factories do
     factory(:user, like: :bob)
-    factory(:admin_user, class: 'User', like: :bob, via: :users) do
+    factory(:admin_user, class: -> { User }, like: :bob, via: :users) do
       { role: :admin }
     end
   end

--- a/lib/fixture_factory/errors.rb
+++ b/lib/fixture_factory/errors.rb
@@ -30,14 +30,32 @@ module FixtureFactory
   end
 
   class WrongClassError < Error
-    def initialize(class_name)
-      super(
-        <<~MSG.squish
-          No class named "#{class_name}".
-          Try using the `class_name` option in your definition to specify a valid class name.
-          https://github.com/Shopify/fixture_factory/blob/master/README.md#naming
-        MSG
-      )
+    def initialize(klass)
+      message = if klass.is_a?(String)
+        string_class_error_message(klass)
+      else
+        proc_class_error_message(klass)
+      end
+      super(message)
+    end
+
+    private
+
+    def proc_class_error_message(proc_class)
+      location, line_number = proc_class.source_location
+      <<~MSG.squish
+        Constant defined in file #{location} on line #{line_number} is not defined.
+        Try using the `class` option in your definition to specify a valid class name.
+        https://github.com/Shopify/fixture_factory/blob/master/README.md#naming
+      MSG
+    end
+
+    def string_class_error_message(class_name)
+      <<~MSG.squish
+        No class named "#{class_name}".
+        Try using the `class_name` option in your definition to specify a valid class name.
+        https://github.com/Shopify/fixture_factory/blob/master/README.md#naming
+      MSG
     end
   end
 end

--- a/lib/fixture_factory/registry.rb
+++ b/lib/fixture_factory/registry.rb
@@ -46,12 +46,13 @@ module FixtureFactory
       #   factory(:admin, via: :users, like: :bob_admin, class: 'User')
       # end
       def factory(name, options = {}, &block)
-        if options.key?(:class)
-          ActiveSupport::Deprecation.warn(<<~MSG.squish)
-            factory class: option is deprecated and will be removed.
-            Please use the class_name: option instead.
-          MSG
-          options[:class_name] ||= options.delete(:class)
+        if options.key?(:class_name)
+          options[:class] ||= -> do
+            class_name = options.delete(:class_name).to_s
+            class_name.constantize
+          rescue NameError
+            raise WrongClassError, class_name
+          end
         end
 
         parent = all_factory_definitions[options[:parent]]

--- a/test/definition_test.rb
+++ b/test/definition_test.rb
@@ -12,16 +12,16 @@ module FixtureFactory
     attr_reader :tested_class, :empty_block
 
     test "#initialize derives from default parent defaults" do
-      subject = tested_class.new(:some_fixtury)
+      subject = tested_class.new(:string)
       assert_instance_of tested_class, subject.parent
+      assert_equal String, subject.klass
+      assert_equal "strings", subject.fixture_method
       assert_nil subject.fixture_name
-      assert_equal "SomeFixtury", subject.class_name
-      assert_equal "some_fixturies", subject.fixture_method
       assert_same empty_block, subject.instance_variable_get(:@block)
     end
 
     test "#initialize allows explicit parent" do
-      parent  = tested_class.new(:parent_fixtury, class_name: "Object", via: :parent_method, like: :parent_name)
+      parent  = tested_class.new(:parent_fixtury, class: -> { Object }, via: :parent_method, like: :parent_name)
       subject = tested_class.new(:child_fixtury, parent: parent)
       assert_same parent, subject.parent
       assert_equal parent.klass, subject.klass
@@ -29,8 +29,8 @@ module FixtureFactory
       assert_equal parent.fixture_name, subject.fixture_name
     end
 
-    test "#initialize allows explicit class name" do
-      subject = tested_class.new(:child_fixtury, class_name: "String")
+    test "#initialize allows explicit class" do
+      subject = tested_class.new(:child_fixtury, class: -> { String })
       assert_equal String, subject.klass
     end
 
@@ -66,21 +66,21 @@ module FixtureFactory
       assert_equal({ parent: true, child: true }, FixtureFactory.evaluate(subject.block, context: self))
     end
 
-    test "#klass constantizes class_name later" do
+    test "#klass= assigns classes normally" do
       subject = tested_class.new(:fixture)
-      subject.class_name = "Object"
+      subject.proc_class = -> { Object }
       assert_equal Object, subject.klass
     end
 
-    test "#klass raises WrongClassError when class name is invalid" do
+    test "#klass raises WrongClassError when class is invalid" do
       subject = tested_class.new(:fixture)
-      subject.class_name = "TheClassIsALie"
+      subject.proc_class = -> { TheClassIsALie }
       error = assert_raises(WrongClassError) do
         subject.klass
       end
       assert_equal <<~MSG.squish, error.message
-        No class named "TheClassIsALie".
-        Try using the `class_name` option in your definition to specify a valid class name.
+        Constant defined in file #{__FILE__} on line 77 is not defined.
+        Try using the `class` option in your definition to specify a valid class name.
         https://github.com/Shopify/fixture_factory/blob/master/README.md#naming
       MSG
     end

--- a/test/fixtury_test.rb
+++ b/test/fixtury_test.rb
@@ -6,7 +6,7 @@ class FixturyTest < FixtureFactory::TestCase
   include FixtureFactory::Registry
 
   define_factories do
-    factory(:post, class_name: "Post") do
+    factory(:post, class: -> { Post }) do
       post_factory_attributes
     end
   end

--- a/test/methods_test.rb
+++ b/test/methods_test.rb
@@ -8,15 +8,15 @@ module FixtureFactory
     include FixtureFactory::Registry
 
     define_factories do
-      factory(:user, class_name: "User") do
+      factory(:user, class: -> { User }) do
         user_factory_attributes
       end
 
-      factory(:address, class_name: "Address") do
+      factory(:address, class: -> { Address }) do
         address_factory_attributes
       end
 
-      factory(:account, class_name: "Account") do
+      factory(:account, class: -> { Account }) do
         account_factory_attributes
       end
     end


### PR DESCRIPTION
I'm currently working on core to prevent dependency violations from test fixtures. To allow Packwerk to detect dependency violations, we need to make constant references more explicit. One way to do that is to update the fixturies library to take a constant model instead of a symbol. That way, Packwerk can pick up on the constant and report dependency violations without being updated.  This circumstance means that we get dependency enforcement without making significant changes to our codebase. I noticed that the class attribute has been deprecated, which shouldn't be the case if [we are going to enforce the class attribute in the factory method](https://github.com/Shopify/shopify/pull/270669/files).

#### Revision 1

As such I'm proposing to revert the changes that deprecated the class attribute #6.
 
#### Revision 2

Based on the comments I changed the PR to take a lambda+constant to achieve the deferred factory class constantization.