### PR TITLE
version bump to 0.3.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    fixture_factory (0.2.1)
+    fixture_factory (0.3.0)
       activemodel (>= 5.2)
       activerecord (>= 5.2)
       activesupport (>= 5.2)

--- a/lib/fixture_factory/version.rb
+++ b/lib/fixture_factory/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module FixtureFactory
-  VERSION = "0.2.1"
+  VERSION = "0.3.0"
 end


### PR DESCRIPTION
In this release, [we reintroduced the `class:` option with the ability to pass a block that exposes a constant](https://github.com/Shopify/fixture_factory/pull/8).
As such I'm bumping the version number for 0.2.1 to 0.3.0

I will tag the commit once it is merged.

