### PR TITLE
Add Ruby 3.0 to build matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ jobs:
         ruby:
           - 2.6
           - 2.7
+          - 3.0
     name: Tests Ruby ${{ matrix.ruby }}
     steps:
       - uses: actions/checkout@v1

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -26,7 +26,7 @@ GEM
     i18n (1.8.2)
       concurrent-ruby (~> 1.0)
     jaro_winkler (1.5.4)
-    minitest (5.14.1)
+    minitest (5.14.4)
     parallel (1.19.1)
     parser (2.7.1.2)
       ast (~> 2.4.0)


### PR DESCRIPTION
minitest 5.14.1 has been bumped because it requires Ruby ~> 2.2.
